### PR TITLE
Define FIND-CLASS generic

### DIFF
--- a/code/defstruct-expand-object.lisp
+++ b/code/defstruct-expand-object.lisp
@@ -5,7 +5,7 @@
 (defun check-included-structure-object (client description environment)
   (when (defstruct-included-structure-name description)
     (let* ((parent-name (defstruct-included-structure-name description))
-           (included-structure (find-class parent-name environment nil))
+           (included-structure (find-class client parent-name nil environment))
            (expected-type (structure-class-name client)))
       (unless included-structure
         (if (structure-description client parent-name environment)
@@ -50,7 +50,9 @@
   ;; All of them, including implicitly included slots.
   (append
    (when (defstruct-included-structure-name description)
-     (loop with included-structure = (find-class (defstruct-included-structure-name description)
+     (loop with included-structure = (find-class client
+                                                 (defstruct-included-structure-name description)
+                                                 t
                                                  environment)
            with included-slots = (defstruct-included-slots description)
            with default-initargs = (closer-mop:class-direct-default-initargs included-structure)
@@ -79,7 +81,7 @@
 
 (defmethod generate-allocation-form (client (description defstruct-object-description) all-slots)
   (declare (ignore client all-slots))
-  `(allocate-instance (find-class ',(defstruct-name description))))
+  `(allocate-instance (cl:find-class ',(defstruct-name description))))
 
 (defmethod generate-slot-initialization-form (client (description defstruct-object-description) layout object slot value)
   (declare (ignore layout))

--- a/code/defstruct-expand-typed.lisp
+++ b/code/defstruct-expand-typed.lisp
@@ -32,7 +32,7 @@
            (let* ((parent-name (defstruct-included-structure-name description))
                   (parent (structure-description client parent-name environment)))
              (unless parent
-               (if (find-class parent-name nil environment)
+               (if (find-class client parent-name nil environment)
                    (error 'included-structure-must-be-typed :name parent-name)
                    (error 'included-structure-does-not-exist :name parent-name)))
              ;; TODO: This should do a subtypep test to make sure the types are the same/compatible...

--- a/code/defstruct-support.lisp
+++ b/code/defstruct-support.lisp
@@ -1,5 +1,7 @@
 (cl:in-package #:anatomicl)
 
+(defgeneric find-class (client symbol &optional errorp environment))
+
 (defgeneric compute-slot-layout (client description environment))
 
 (defgeneric layout-slots (client description layout))
@@ -18,6 +20,10 @@
 (defgeneric client-form (client))
 
 (defgeneric standard-constructor-p (object))
+
+(defmethod find-class (client symbol &optional (errorp t) environment)
+  (declare (ignore client))
+  (cl:find-class symbol errorp environment))
 
 ;;; BOA constructors are a more complicated as they have the ability
 ;;; to completely override any specified slot initforms. So, in some

--- a/code/interface.lisp
+++ b/code/interface.lisp
@@ -27,11 +27,11 @@
                                  :initform nil
                                  :reader standard-constructor-p)))
 
-       (defmethod closer-mop:validate-superclass ((class ,structure-class-name) (superclass (eql (find-class 't))))
+       (defmethod closer-mop:validate-superclass ((class ,structure-class-name) (superclass (eql (cl:find-class 't))))
          ;; T is not a valid direct superclass, all structures inherit from STRUCTURE-OBJECT.
          nil)
 
-       (defmethod closer-mop:validate-superclass ((class ,structure-class-name) (superclass (eql (find-class 'standard-object))))
+       (defmethod closer-mop:validate-superclass ((class ,structure-class-name) (superclass (eql (cl:find-class 'standard-object))))
          ;; Only STRUCTURE-OBJECT may have STANDARD-OBJECT as a direct superclass, all
          ;; other structure classes must inherit from STRUCTURE-OBJECT.
          #-(or abcl clasp) (eql (class-name class) ',structure-object-name)
@@ -52,11 +52,11 @@
 
        (defmethod closer-mop:direct-slot-definition-class ((class ,structure-class-name) &rest initargs)
          (declare (ignore initargs))
-         (find-class 'structure-direct-slot-definition))
+         (cl:find-class 'structure-direct-slot-definition))
 
        (defmethod closer-mop:effective-slot-definition-class ((class ,structure-class-name) &rest initargs)
          (declare (ignore initargs))
-         (find-class 'structure-effective-slot-definition))
+         (cl:find-class 'structure-effective-slot-definition))
 
        (defmethod structure-object-name ((client ,client-class))
          ',structure-object-name)

--- a/code/packages.lisp
+++ b/code/packages.lisp
@@ -3,11 +3,12 @@
 (defpackage #:anatomicl
   (:use #:common-lisp)
   #+sicl (:local-nicknames (#:closer-mop #:sicl-clos))
-  (:shadow #:copy-structure)
+  (:shadow #:find-class #:copy-structure)
   (:export #:client-form
            #:copy-structure
            #:define-interface
            #:expand-defstruct
+           #:find-class
            #:parse-defstruct
            #:print-structure
            #:standard-constructor-p

--- a/code/read-structure.lisp
+++ b/code/read-structure.lisp
@@ -13,7 +13,7 @@
            (unless (oddp (list-length form))
              (error 'missing-sharp-s-argument :stream stream))
            (let* ((structure-name (first form))
-                  (class (find-class structure-name nil)))
+                  (class (find-class client structure-name nil)))
              (unless (and class (typep class (structure-class-name client)))
                (error 'sharp-s-class-must-name-structure-class
                       :stream stream


### PR DESCRIPTION
This allows clients to control how macros look up classes. For example, it's useful if the client is working with an environment other than the host environment.

A default method is provided that uses CL:FIND-CLASS, so clients do not need to specialize this function.

This is necessary for me to use Anatomicl to implement `defstruct` for the cross-clasp-compiler.